### PR TITLE
[Feat]: 소셜 로그인 구현

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -131,3 +131,9 @@ fabric.properties
 *storybook.log
 *.mdc
 dist/
+
+.env
+.env.local
+.env.development.local
+.env.test.local
+.env.production.local

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,22 +1,75 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import { GlobalStyle } from "./styles/GlobalStyle.ts";
 import LandingPage from './components/common/LandingPage';
 import RepoTreePage from './components/pages/RepoTreePage';
 import PhysicsGraphTestPage from './components/pages/PhysicsGraphTestPage';
 import RepositoryHistoryPage from './components/pages/RepositoryHistoryPage';
-import { BrowserRouter, Routes, Route } from 'react-router-dom';
+import { BrowserRouter, Routes, Route, useNavigate, useLocation } from 'react-router-dom';
 import HomePage from './components/pages/HomePage.tsx';
 import AppLayout from './components/layout/AppLayout';
 import RepositorySection from './components/common/RepositorySection';
 import NewRepositorySection from './components/common/NewRepositorySection';
+import LoginCallback from './components/auth/LoginCallback';
+import AuthService from './api/auth';
+
+// URL 파라미터 토큰 처리를 위한 래퍼 컴포넌트
+const TokenHandler: React.FC = () => {
+  const navigate = useNavigate();
+  const location = useLocation();
+  
+  useEffect(() => {
+    // 현재 URL이 루트 페이지이고 토큰 파라미터가, 포함되어 있다면 처리
+    if (location.pathname === '/' && location.search.includes('accessToken')) {
+      const token = AuthService.getTokenFromUrl();
+      
+      if (token) {
+        // 토큰 저장
+        AuthService.saveToken(token);
+        
+        // 토큰을 제외한 URL로 리다이렉트
+        navigate('/home', { replace: true });
+      }
+    }
+  }, [location, navigate]);
+  
+  return null;
+};
 
 function App() {
+  const [isLoading, setIsLoading] = useState(true);
+  
+  // 앱 초기화 시 인증 상태 확인
+  useEffect(() => {
+    const checkAuth = async () => {
+      try {
+        const isAuthenticated = await AuthService.isAuthenticated();
+        if (isAuthenticated) {
+          console.log('사용자가 로그인되어 있습니다.');
+        }
+      } catch (error) {
+        console.error('인증 상태 확인 중 오류 발생:', error);
+      } finally {
+        setIsLoading(false);
+      }
+    };
+    
+    checkAuth();
+  }, []);
+  
+  // 로딩 중인 경우 빈 화면 표시
+  if (isLoading) {
+    return <div>로딩 중...</div>;
+  }
+  
   return (
     <>
       <GlobalStyle />
       <BrowserRouter>
+        <TokenHandler />
         <Routes>
           <Route path="/" element={<LandingPage />} />
+          {/* 소셜 로그인 콜백 처리를 위한 라우트 추가 */}
+          <Route path="/login/callback" element={<LoginCallback />} />
           <Route path="/home" element={<AppLayout />}>
             <Route index element={<HomePage />} />
           </Route>

--- a/src/api/auth.ts
+++ b/src/api/auth.ts
@@ -1,0 +1,58 @@
+import api from './axios';
+
+/**
+ * 인증 서비스 - 토큰 기반 인증
+ */
+const AuthService = {
+  // 사용자 인증 상태 확인
+  isAuthenticated: async (): Promise<boolean> => {
+    try {
+      // localStorage에서 토큰 확인
+      const token = localStorage.getItem('accessToken');
+      
+      if (!token) {
+        return false;
+      }
+      
+      // 토큰 유효성 검증을 위한 API 요청
+      await api.get('/api/auth/check');
+      return true;
+    } catch (error) {
+      return false;
+    }
+  },
+
+  // 로그아웃 - 토큰 삭제
+  logout: async (): Promise<void> => {
+    try {
+      await api.post('/api/auth/logout');
+      // 로컬 스토리지에서 토큰 제거
+      localStorage.removeItem('accessToken');
+    } catch (error) {
+      console.error('로그아웃 중 오류 발생:', error);
+    }
+  },
+
+  // 소셜 로그인 URL 생성
+  getSocialLoginUrl: (provider: 'google' | 'kakao'): string => {
+    return `${import.meta.env.VITE_API_URL}/oauth2/authorization/${provider}`;
+  },
+  
+  // URL에서 토큰 추출
+  getTokenFromUrl: (): string | null => {
+    const urlParams = new URLSearchParams(window.location.search);
+    return urlParams.get('accessToken');
+  },
+  
+  // 토큰 저장
+  saveToken: (token: string): void => {
+    localStorage.setItem('accessToken', token);
+  },
+  
+  // 토큰 가져오기
+  getToken: (): string | null => {
+    return localStorage.getItem('accessToken');
+  }
+};
+
+export default AuthService; 

--- a/src/api/axios.ts
+++ b/src/api/axios.ts
@@ -1,10 +1,29 @@
 import axios from "axios";
 
 const api = axios.create({
-  baseURL: import.meta.env.VITE_API_URL,
+  baseURL: "/", // 기본 URL을 프록시 사용을 위해 상대 경로로 변경
   headers: {
     "Content-Type": "application/json",
   },
+  withCredentials: true, // 쿠키를 요청과 함께 전송
 });
+
+// 요청 인터셉터 추가
+api.interceptors.request.use(
+  (config) => {
+    // localStorage에서 액세스 토큰 가져오기
+    const token = localStorage.getItem('accessToken');
+    
+    // 토큰이 있는 경우 요청 헤더에 추가
+    if (token) {
+      config.headers['Authorization'] = `Bearer ${token}`;
+    }
+    
+    return config;
+  },
+  (error) => {
+    return Promise.reject(error);
+  }
+);
 
 export default api;

--- a/src/components/auth/LoginCallback.tsx
+++ b/src/components/auth/LoginCallback.tsx
@@ -1,0 +1,102 @@
+import React, { useEffect, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import styled from 'styled-components';
+import AuthService from '../../api/auth';
+
+const LoadingContainer = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  height: 100vh;
+  background: linear-gradient(180deg, #F7FAFF 0%, #E3EDFF 100%);
+`;
+
+const Spinner = styled.div`
+  border: 4px solid rgba(0, 0, 0, 0.1);
+  border-radius: 50%;
+  border-top: 4px solid #6C9EFF;
+  width: 40px;
+  height: 40px;
+  animation: spin 1s linear infinite;
+  margin-bottom: 20px;
+  
+  @keyframes spin {
+    0% { transform: rotate(0deg); }
+    100% { transform: rotate(360deg); }
+  }
+`;
+
+const LoadingText = styled.p`
+  font-family: 'Pretendard', 'Inter', sans-serif;
+  font-size: 16px;
+  color: #333;
+  font-weight: 500;
+`;
+
+const ErrorText = styled.p`
+  font-family: 'Pretendard', 'Inter', sans-serif;
+  font-size: 16px;
+  color: #e74c3c;
+  font-weight: 500;
+  margin-top: 20px;
+`;
+
+const LoginCallback: React.FC = () => {
+  const navigate = useNavigate();
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    const processLogin = async () => {
+      try {
+        // URL에서 토큰 추출
+        const token = AuthService.getTokenFromUrl();
+        
+        if (token) {
+          // 토큰을 로컬 스토리지에 저장
+          AuthService.saveToken(token);
+          
+          // 인증 확인 테스트
+          const isAuthenticated = await AuthService.isAuthenticated();
+          
+          if (isAuthenticated) {
+            // 인증되었으면 홈으로 이동
+            navigate('/home');
+          } else {
+            // 토큰은 있지만 유효하지 않은 경우
+            setError('인증에 실패했습니다. 유효하지 않은 토큰입니다.');
+            // 토큰 제거
+            localStorage.removeItem('accessToken');
+            setTimeout(() => {
+              navigate('/');
+            }, 2000);
+          }
+        } else {
+          // 토큰이 없는 경우
+          setError('로그인에 실패했습니다. 토큰이 없습니다.');
+          setTimeout(() => {
+            navigate('/');
+          }, 2000);
+        }
+      } catch (err) {
+        // 오류 발생 시 처리
+        setError('로그인 중 오류가 발생했습니다.');
+        setTimeout(() => {
+          navigate('/');
+        }, 2000);
+      }
+    };
+
+    processLogin();
+  }, [navigate]);
+
+  return (
+    <LoadingContainer>
+      <Spinner />
+      <LoadingText>로그인 중입니다...</LoadingText>
+      {error && <ErrorText>{error}</ErrorText>}
+    </LoadingContainer>
+  );
+};
+
+export default LoginCallback; 

--- a/src/components/common/LandingHero.tsx
+++ b/src/components/common/LandingHero.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import styled from 'styled-components';
 import LoginButton from './LoginButton';
+import AuthService from '../../api/auth';
 
 const HeroWrapper = styled.section`
   width: 100vw;
@@ -73,23 +74,43 @@ const MacbookImage = styled.img`
   border-radius: 24px;
 `;
 
-const LandingHero: React.FC = () => (
-  <HeroWrapper aria-label="히어로 섹션" tabIndex={0} id="intro">
-    <Content>
-      <Title>복잡한 파일 관리,</Title>
-      <SubTitle><HighlightText>DocStory</HighlightText>가 해결합니다.</SubTitle>
-      <Desc>
-        문서를 업로드하고, 문서 흐름을 간편하게 관리해보세요. 
-        팀원들과 협업까지 간편하게 가능합니다.
-      </Desc>
-      <ButtonRow>
-        <LoginButton type="google">구글 계정으로 로그인</LoginButton>
-        <LoginButton type="kakao">카카오 계정으로 로그인</LoginButton>
-        <LoginButton type="guest">로그인 없이 체험해보기</LoginButton>
-      </ButtonRow>
-    </Content>
-    <MacbookImage src="/assets/examImage.svg" alt="Macbook Air 일러스트" />
-  </HeroWrapper>
-);
+const LinkWrapper = styled.a`
+  text-decoration: none;
+`;
+
+const LandingHero: React.FC = () => {
+  // 소셜 로그인 핸들러
+  const handleGoogleLogin = () => {
+    window.location.href = AuthService.getSocialLoginUrl('google');
+  };
+  
+  const handleKakaoLogin = () => {
+    window.location.href = AuthService.getSocialLoginUrl('kakao');
+  };
+  
+  const handleGuestLogin = () => {
+    // 게스트 로그인 로직
+    console.log('게스트 로그인');
+  };
+
+  return (
+    <HeroWrapper aria-label="히어로 섹션" tabIndex={0} id="intro">
+      <Content>
+        <Title>복잡한 파일 관리,</Title>
+        <SubTitle><HighlightText>DocStory</HighlightText>가 해결합니다.</SubTitle>
+        <Desc>
+          문서를 업로드하고, 문서 흐름을 간편하게 관리해보세요. 
+          팀원들과 협업까지 간편하게 가능합니다.
+        </Desc>
+        <ButtonRow>
+          <LoginButton type="google" onClick={handleGoogleLogin}>구글 계정으로 로그인</LoginButton>
+          <LoginButton type="kakao" onClick={handleKakaoLogin}>카카오 계정으로 로그인</LoginButton>
+          <LoginButton type="guest" onClick={handleGuestLogin}>로그인 없이 체험해보기</LoginButton>
+        </ButtonRow>
+      </Content>
+      <MacbookImage src="/assets/examImage.svg" alt="Macbook Air 일러스트" />
+    </HeroWrapper>
+  );
+};
 
 export default LandingHero;


### PR DESCRIPTION
## 📄요약

> 로그인 처리를 구현한다. 

## 🖋️작업 내용

- [x] 랜딩페이지에서 소셜 로그인 버튼과 로그인 URL 연결
- [x] 로그인 후 토큰을 헤더에 추가하도록 구현

## 📷스크린샷
<img width="1277" alt="image" src="https://github.com/user-attachments/assets/fecfe6ad-da12-45b4-8b80-5b741dffc750" />


## ❗참고 사항
https://kanguk-room.notion.site/Frontend-1f2036cad7a880d9b028e67792dcb121?pvs=4

## 🔗이슈
close #11 
